### PR TITLE
Reset `base::Thread::delegate_` on main thread only

### DIFF
--- a/base/threading/thread.cc
+++ b/base/threading/thread.cc
@@ -102,8 +102,8 @@ void Thread::join() {
   delegate_.reset();
 }
 
-void Thread::RegisterDelegateResetCallbackForTesting(OnceClosure cb) {
-  delegate_reset_callback_for_testing_ = std::move(cb);
+void Thread::RegisterBackingThreadTerminateCallbackForTesting(OnceClosure cb) {
+  backing_thread_terminate_callback_for_testing_ = std::move(cb);
 }
 
 // static
@@ -113,8 +113,8 @@ void* Thread::ThreadFunc(void* in) {
 
   thread->ThreadMain();
 
-  if (thread->delegate_reset_callback_for_testing_)
-    thread->delegate_reset_callback_for_testing_();
+  if (thread->backing_thread_terminate_callback_for_testing_)
+    thread->backing_thread_terminate_callback_for_testing_();
 
   pthread_exit(0);
 }

--- a/base/threading/thread.h
+++ b/base/threading/thread.h
@@ -59,7 +59,7 @@ class Thread {
   static void sleep_for(std::chrono::milliseconds ms);
   void join();
 
-  void RegisterDelegateResetCallbackForTesting(OnceClosure cb);
+  void RegisterBackingThreadTerminateCallbackForTesting(OnceClosure cb);
 
  protected:
   // These methods run on the newly-created thread.
@@ -110,7 +110,7 @@ class Thread {
   // would technically run *during* the backing thread's `Run()` loop. This is a
   // more explicit signal that the internal run loop has ended, and this is the
   // final hook that can run before thread termination.
-  OnceClosure delegate_reset_callback_for_testing_;
+  OnceClosure backing_thread_terminate_callback_for_testing_;
 };
 
 } // namespace base

--- a/base/threading/thread_test.cc
+++ b/base/threading/thread_test.cc
@@ -89,7 +89,7 @@ TEST_P(ThreadTest, GetTaskRunnerBeforeStart) {
 TEST_P(ThreadTest, StartAfterThreadTerminatesButBeforeJoinOrStop) {
   std::shared_ptr<TaskLoop> delegate_reset_waiter =
     TaskLoop::Create(ThreadType::WORKER);
-  thread->RegisterDelegateResetCallbackForTesting(
+  thread->RegisterBackingThreadTerminateCallbackForTesting(
     delegate_reset_waiter->QuitClosure());
 
   thread->Start();

--- a/base/threading/thread_test.cc
+++ b/base/threading/thread_test.cc
@@ -102,9 +102,11 @@ TEST_P(ThreadTest, StartAfterThreadTerminatesButBeforeJoinOrStop) {
   delegate_reset_waiter->Run();
 
   // At this point we know that the thread's delegate has been "quit" and the
-  // underlying thread has been entirely terminated. Delegate should be reset
-  // and therefore unable to produce task runners.
-  EXPECT_FALSE(thread->GetTaskRunner());
+  // underlying thread has been entirely terminated. The internal delegate,
+  // which vends per-base::Thread TaskRunners, however, does not get reset until
+  // `Stop()` is called, so it is able to produce TaskRunners for the underlying
+  // thread even if it has terminated itself.
+  EXPECT_TRUE(thread->GetTaskRunner());
 
   // Calling |Start()| should fail because neither |Stop()| nor |join()| have
   // been called yet.


### PR DESCRIPTION
This commit resets the `reset()` of `base::Thread::delegate_` to be on the main thread only, instead of on the backing thread when it terminates. The previous design was bad because it meant the API surface of `base::Thread` (`GetTaskRunner()` specifically) could change unpredictably by the backing thread terminating itself. This new design ensures that `base::Thread::delegate_` is only ever mutated on the main thread, and clarifies that this is thread-safe because it is only ever reset after the backing thread is terminated/joined.

Closes #1.