### PR TITLE
Make TaskLoopForIO-specifc handles use that type specifically

### DIFF
--- a/base/scheduling/scheduling_handles.cc
+++ b/base/scheduling/scheduling_handles.cc
@@ -4,6 +4,7 @@
 
 #include "base/check.h"
 #include "base/scheduling/task_loop.h"
+#include "base/scheduling/task_loop_for_io.h"
 
 namespace base {
 
@@ -12,7 +13,7 @@ namespace base {
 // These are weak process-global pointers to underlying |TaskLoop|s that we wish
 // to reference but not keep alive.
 static std::weak_ptr<TaskLoop> g_ui_task_loop;
-static std::weak_ptr<TaskLoop> g_io_task_loop;
+static std::weak_ptr<TaskLoopForIO> g_io_task_loop;
 
 // Thread-global pointers (global only within a thread).
 // Weak pointer for the same reason above.
@@ -22,7 +23,7 @@ void SetUIThreadTaskLoop(std::weak_ptr<TaskLoop> ui_task_loop) {
   g_ui_task_loop = ui_task_loop;
 }
 
-void SetIOThreadTaskLoop(std::weak_ptr<TaskLoop> io_task_loop) {
+void SetIOThreadTaskLoop(std::weak_ptr<TaskLoopForIO> io_task_loop) {
   g_io_task_loop = io_task_loop;
 }
 
@@ -39,8 +40,8 @@ std::shared_ptr<TaskLoop> GetUIThreadTaskLoop() {
   return task_loop;
 }
 
-std::shared_ptr<TaskLoop> GetIOThreadTaskLoop() {
-  std::shared_ptr<TaskLoop> task_loop = g_io_task_loop.lock();
+std::shared_ptr<TaskLoopForIO> GetIOThreadTaskLoop() {
+  std::shared_ptr<TaskLoopForIO> task_loop = g_io_task_loop.lock();
   return task_loop;
 }
 

--- a/base/scheduling/scheduling_handles.h
+++ b/base/scheduling/scheduling_handles.h
@@ -3,18 +3,22 @@
 
 #include <memory>
 
+// We cannot forward declare the `TaskLoopForIO` type because it is redefined at
+// compile-time by the following include, which cannot be captured by a raw
+// declaration.
+#include "base/scheduling/task_loop_for_io.h"
+
 namespace base {
 
 class TaskLoop;
 class TaskRunner;
 
 void SetUIThreadTaskLoop(std::weak_ptr<TaskLoop>);
-void SetIOThreadTaskLoop(std::weak_ptr<TaskLoop>);
+void SetIOThreadTaskLoop(std::weak_ptr<TaskLoopForIO>);
 void SetCurrentThreadTaskLoop(std::weak_ptr<TaskLoop>);
 
 std::shared_ptr<TaskLoop> GetUIThreadTaskLoop();
-// TODO(domfarolino): Consider returning `TaskLoopForIO` directly.
-std::shared_ptr<TaskLoop> GetIOThreadTaskLoop();
+std::shared_ptr<TaskLoopForIO> GetIOThreadTaskLoop();
 std::shared_ptr<TaskLoop> GetCurrentThreadTaskLoop();
 std::shared_ptr<TaskRunner> GetCurrentThreadTaskRunner();
 

--- a/base/scheduling/task_loop.cc
+++ b/base/scheduling/task_loop.cc
@@ -21,7 +21,8 @@ void TaskLoop::BindToCurrentThread(ThreadType type) {
       break;
     case ThreadType::IO:
       CHECK(!GetIOThreadTaskLoop());
-      SetIOThreadTaskLoop(GetWeakPtr());
+      SetIOThreadTaskLoop(
+          std::dynamic_pointer_cast<TaskLoopForIO>(shared_from_this()));
       CHECK(GetIOThreadTaskLoop());
       break;
     case ThreadType::WORKER:

--- a/base/scheduling/task_loop_for_io_test.cc
+++ b/base/scheduling/task_loop_for_io_test.cc
@@ -78,12 +78,10 @@ class TestSocketReader : public base::TaskLoopForIO::SocketReader {
   TestSocketReader(int fd, TaskLoopForIOTestBase& callback_object) :
     base::TaskLoopForIO::SocketReader::SocketReader(fd),
     callback_object_(callback_object) {
-    std::static_pointer_cast<base::TaskLoopForIO>(
-      base::GetIOThreadTaskLoop())->WatchSocket(this);
+    base::GetIOThreadTaskLoop()->WatchSocket(this);
   }
   ~TestSocketReader() {
-    std::static_pointer_cast<base::TaskLoopForIO>(
-      base::GetIOThreadTaskLoop())->UnwatchSocket(this);
+    base::GetIOThreadTaskLoop()->UnwatchSocket(this);
   }
 
   void OnCanReadFromSocket() override {


### PR DESCRIPTION
This commit makes the `base::SetIOThreadTaskLoop()` and `base::GetIOThreadTaskLoop()` scheduling handle functions use the `base::TaskLoopForIO` type explicitly. This makes it easier for embedders to call GetIOThreadTaskLoop() since they never have to cast to `TaskLoopForIO` to do IO-specific things.

Closes #2.